### PR TITLE
Add UUID information in settings panel

### DIFF
--- a/plugin/src/main/kotlin/com/testknight/settings/SettingsComponent.kt
+++ b/plugin/src/main/kotlin/com/testknight/settings/SettingsComponent.kt
@@ -20,7 +20,6 @@ import com.testknight.actions.settings.DeleteElementAction
 import com.testknight.actions.settings.EditElementAction
 import com.testknight.actions.settings.ResetTreeAction
 import com.testknight.models.ParameterSuggestionTreeModel
-import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.event.TreeModelEvent
 import javax.swing.event.TreeModelListener

--- a/plugin/src/main/kotlin/com/testknight/settings/SettingsComponent.kt
+++ b/plugin/src/main/kotlin/com/testknight/settings/SettingsComponent.kt
@@ -20,6 +20,7 @@ import com.testknight.actions.settings.DeleteElementAction
 import com.testknight.actions.settings.EditElementAction
 import com.testknight.actions.settings.ResetTreeAction
 import com.testknight.models.ParameterSuggestionTreeModel
+import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.event.TreeModelEvent
 import javax.swing.event.TreeModelListener
@@ -46,6 +47,9 @@ class SettingsComponent {
     init {
         myPanel = panel {
             titledRow("Telemetry") {
+                row {
+                    label("Your UUID: ${state.userId}")
+                }
                 row {
                     checkBox(
                         "Allow data collection",


### PR DESCRIPTION
# What has changed between the versions
Added a field in the settings panel which shows the user's UUID.
![image](https://user-images.githubusercontent.com/26065332/122885787-af288200-d33f-11eb-8115-f33dd3573df3.png)

# Why we need this merge request

To let the user know their UUID if they request to delete their data.

# Change-log/Release notes
- Added a field in the settings panel which shows the user's UUID.