### PR TITLE
Fix UI update bug when adding a new class/value multiple times

### DIFF
--- a/plugin/src/main/kotlin/com/testknight/models/ParameterSuggestionTreeModel.kt
+++ b/plugin/src/main/kotlin/com/testknight/models/ParameterSuggestionTreeModel.kt
@@ -43,15 +43,16 @@ class ParameterSuggestionTreeModel(private var paramSuggestionMap: MutableMap<St
      * Adds the node pointed by the TreePath.
      *
      * @param path The path of the node to be added.
+     * @return True if the new element is added, false if it is not added.
      */
-    fun addPathElement(path: TreePath) {
+    fun addPathElement(path: TreePath): Boolean {
         if (path.parentPath.lastPathComponent == rootNode) {
             checkPath(path, true)
             val className = path.lastPathComponent as String
 
             // Item already exists, don't have to reset or add it again.
             if (paramSuggestionMap.containsKey(className)) {
-                return
+                return false
             }
 
             paramSuggestionMap[className] = mutableListOf()
@@ -68,7 +69,7 @@ class ParameterSuggestionTreeModel(private var paramSuggestionMap: MutableMap<St
             if (paramSuggestionMap.containsKey(className) &&
                 paramSuggestionMap[className]!!.contains(typeName)
             ) {
-                return
+                return false
             }
 
             paramSuggestionMap[className]?.add(typeName)
@@ -78,6 +79,8 @@ class ParameterSuggestionTreeModel(private var paramSuggestionMap: MutableMap<St
             treeStructureChanged(path.parentPath, intArrayOf(index), arrayOf(typeName))
             treeNodesInserted(path, intArrayOf(index), arrayOf(className))
         }
+
+        return true
     }
 
     /**

--- a/plugin/src/main/kotlin/com/testknight/models/ParameterSuggestionTreeModel.kt
+++ b/plugin/src/main/kotlin/com/testknight/models/ParameterSuggestionTreeModel.kt
@@ -48,6 +48,12 @@ class ParameterSuggestionTreeModel(private var paramSuggestionMap: MutableMap<St
         if (path.parentPath.lastPathComponent == rootNode) {
             checkPath(path, true)
             val className = path.lastPathComponent as String
+
+            // Item already exists, don't have to reset or add it again.
+            if (paramSuggestionMap.containsKey(className)) {
+                return
+            }
+
             paramSuggestionMap[className] = mutableListOf()
 
             val index = getIndexOfChild(rootNode, className)
@@ -57,6 +63,13 @@ class ParameterSuggestionTreeModel(private var paramSuggestionMap: MutableMap<St
             checkPath(path, false)
             val className = path.parentPath.lastPathComponent as String
             val typeName = path.lastPathComponent as String
+
+            // Item already exists, don't have to reset or add it again.
+            if (paramSuggestionMap.containsKey(className) &&
+                paramSuggestionMap[className]!!.contains(typeName)
+            ) {
+                return
+            }
 
             paramSuggestionMap[className]?.add(typeName)
                 ?: throw InvalidTreePathException("Class doesn't exist in Parameter Suggestion")

--- a/plugin/src/test/kotlin/com/testknight/models/ParameterSuggestionTreeModelTest.kt
+++ b/plugin/src/test/kotlin/com/testknight/models/ParameterSuggestionTreeModelTest.kt
@@ -34,20 +34,38 @@ internal class ParameterSuggestionTreeModelTest : TestKnightTestCase() {
     fun testAddPathElementClass() {
         val tree = ParameterSuggestionTreeModel(parameterSuggestionMap.toMutableMap())
         val path = TreePath(tree.root).pathByAddingChild("byte")
-        tree.addPathElement(path)
+        val ret = tree.addPathElement(path)
         val expected = listOf("String", "int", "byte")
         val actual = tree.getChildren(tree.root)
         TestCase.assertEquals(expected, actual)
+        TestCase.assertEquals(true, ret)
     }
 
     @Test
     fun testAddPathElementValue() {
         val tree = ParameterSuggestionTreeModel(parameterSuggestionMap.toMutableMap())
         val path = TreePath(tree.root).pathByAddingChild("int").pathByAddingChild("3")
-        tree.addPathElement(path)
+        val ret = tree.addPathElement(path)
         val expected = listOf("1", "2", "0", "3")
         val actual = tree.getChildren("int")
         TestCase.assertEquals(expected, actual)
+        TestCase.assertEquals(true, ret)
+    }
+
+    @Test
+    fun testAddDuplicatePathElementValue() {
+        val tree = ParameterSuggestionTreeModel(parameterSuggestionMap.toMutableMap())
+        val path = TreePath(tree.root).pathByAddingChild("int").pathByAddingChild("1")
+        val ret = tree.addPathElement(path)
+        TestCase.assertEquals(false, ret)
+    }
+
+    @Test
+    fun testAddDuplicatePathElementClass() {
+        val tree = ParameterSuggestionTreeModel(parameterSuggestionMap.toMutableMap())
+        val path = TreePath(tree.root).pathByAddingChild("int")
+        val ret = tree.addPathElement(path)
+        TestCase.assertEquals(false, ret)
     }
 
     @Test


### PR DESCRIPTION
# What has changed between the versions
Added a check to see if the newly added element exists in the tree. If it exists, then the function returns and structure-change/node-inserted notifier isn't called. 

# Why we need this pull request
Fixes the settings param suggestion's tree bug where the UI adds empty space when repeatedly pressing add new class/element button.

# Change-log/Release notes
* Added check to see if the newly added element exists in the tree
* Changed return type of addPathElement from void to Boolean. True of the element is added, false otherwise.
* Added 2 new tests for addPathElement to check when return type is false when adding a value and a class.