### PR TITLE
Fix compatibility issues and add support to 2021.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -21,12 +21,17 @@
 -->
 
 ## [1.0.1]
+
+### Added
+- Added support for build 212.
+### Changed
+- Improved checklist generation parsing strategy.
+- Changed how notifications are registered to 2020.3 and later version.
+### Removed
+- Removed support for build 202.
 ### Fixed
 - Fix coverage not showing for classes inside a package.
 - Fix parameter suggestions tree adding empty class/values.
-- Fix incompatibility with build 212.
-### Changed
-- Improved checklist generation parsing strategy.
 
 ## [1.0.0]
 - Initial release.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,104 @@
+  # TestKnight
+
+The repository includes the TestKnight's plugin code as well as the code of the telemetry server used to collect
+usage information.
+
+<!-- Plugin description -->
+## What is TestKnight?
+
+TestKnight is an all in one plugin for IntelliJ IDEA that helps you write automatic tests for your codebase.
+Specifically, TestKnight extends your IDE to allow you to design test-suites based on structural and side-effect
+analysis of your code as well as inspect how your test-suite evolves.
+
+Install it via IntelliJ's marketplace!
+
+## Key Features:
+
+
+### Testing checklist
+
+Generate testing checklists for methods/classes based on structural and black-box testing.
+
+<img src="https://raw.githubusercontent.com/SERG-Delft/testknight/master/screenshots/testing-checklist.png" width=600>
+
+#### Test case List
+
+Quickly navigate between the test cases within a test file.
+
+<img src="https://raw.githubusercontent.com/SERG-Delft/testknight/master/screenshots/test-list.gif" width="600">
+
+### Differential coverage
+
+When you run with coverage twice you can see the lines of code covered by the most recent test-run in a brighter green.
+  
+<img src="https://raw.githubusercontent.com/SERG-Delft/testknight/master/screenshots/diff-cov.png" width=600>
+
+Additionally you can compare coverage with the previous run by pressing the "Diff" button for the class:
+
+<img src="https://raw.githubusercontent.com/SERG-Delft/testknight/master/screenshots/diff-window.png" width=600>
+
+### See lines covered by a test
+
+If coverage information is available, testKnight will allow you to highlight the lines covered by a specific test case.
+
+<img src="https://raw.githubusercontent.com/SERG-Delft/testknight/master/screenshots/traceability.gif" width=600>
+
+### Assertion suggestions
+
+TestKnight can detect the side-effects in a method and suggest assertions for the method under test.
+
+<img src="https://raw.githubusercontent.com/SERG-Delft/testknight/master/screenshots/assertion-suggestions.gif" width=600>
+
+#### Test Duplication
+
+Easily duplicate an existing test method and change the values of often-changed code elements such as constructor arguments and literals.
+ 
+<img src="https://raw.githubusercontent.com/SERG-Delft/testknight/master/screenshots/duplicate-test.gif" width="600">
+
+TestKnight is designed with the user in mind.
+We have strived to create a tool that is intuitive to use and unintrusive. That means no annoying pop-ups while coding, no error messages and no breaking your flow.
+<!-- Plugin description end -->
+
+## Some background information
+TestKnight was originally envisioned by the TU Delft Software Engineering Research Group. The project was assigned to 5 Bachelor students at the same university
+as part of the CSE2000 course. The original version of it was developed within 2 months in a university GitLab instance and in the end the project was migrated
+to GitHub for everyone to see. 
+
+Development wise, the plugin is developed using Kotlin and utilizing the IntelliJ SDK whereas the telemetry server is a simple Spring Boot application. 
+Lastly, we have used `Gradle` as a build tool for both the plugin and the server.
+
+## Structure of the repository
+This repository consists of 2 main submodules.
+* The `/plugin` directory contains all the source code and configuration files of the actual plugin.
+* The `/server` directory contains all the source code and configuration files for the telemetry server.
+
+Additionally, the `/documentation` directory includes useful documentation and design documents. Moreover, it includes 2 educational
+documents to help you get started with Kotlin and with the IntelliJ SDK.  
+
+## Running Instructions
+In this section you can find instructions on how to run the different parts of TestKnight for development purposes.
+
+### Running the Plugin
+After cloning the repository you can navigate to the `/plugin` directory. From there you can run: 
+
+```
+gradle runIde
+```
+
+this should open an IntelliJ instance with the plugin loaded.
+
+#### Running from within IntelliJ
+
+Alternatively, after cloning the project you can open it with IntelliJ IDEA and from there you can use the 'Gradle' tab and run options. From the tab you can go to `plugin -> Tasks -> intellij -> runIde`. Otherwise, you can set the run configuration to `Run Plugin`.
+
+### Running the Server
+Similarly to above, after cloning the repository you can navigate to the `/server` directory and run `gradle bootRun`.
+Alternatively, you can open the project in IntelliJ IDEA and run the server either by the `gradle` tab by going on 
+`server -> Tasks -> application -> bootRun` or by setting `TESTKNIGHTTELEMETRYSERVERAPPLICATION` as the run configuration.
+
+
+## Team
+  
+TestKnight is proudly developed by: Cristian Botocan, Jorge Romeu Huidobro, Mathanrajan Sundarrajan, Piyush Deshmukh, and Pavlos Makridis. 
+
+This project is developed under the supervision of Pouria Derakhshanfar, Mark Swillus, Maurício Aniche, and Andy Zaidman, all members of the [Software Engineering Research Group (SERG)](https://se.ewi.tudelft.nl/) of the [Delft University of Technology](https://www.tudelft.nl), in the Netherlands.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.3.0"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.16.0"
+    id("io.gitlab.arturbosch.detekt") version "1.18.1"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
     // jacoco code coverage - read more: https://github.com/jacoco/jacoco

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,5 +1,4 @@
 import io.gitlab.arturbosch.detekt.Detekt
-import org.jetbrains.changelog.closure
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -9,13 +8,13 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.4.32"
+    id("org.jetbrains.kotlin.jvm") version "1.5.30"
     // kotlin serialization
     kotlin("plugin.serialization") version "1.5.10"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "0.7.2"
+    id("org.jetbrains.intellij") version "1.1.6"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "1.1.2"
+    id("org.jetbrains.changelog") version "1.3.0"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
     id("io.gitlab.arturbosch.detekt") version "1.16.0"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
@@ -30,7 +29,7 @@ version = properties("pluginVersion")
 // Configure project's dependencies
 repositories {
     mavenCentral()
-    jcenter()
+//    jcenter()
 }
 
 dependencies {
@@ -50,21 +49,20 @@ dependencies {
 // Configure gradle-intellij-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-    pluginName = properties("pluginName")
-    version = properties("platformVersion")
-    type = properties("platformType")
-    downloadSources = properties("platformDownloadSources").toBoolean()
-    updateSinceUntilBuild = true
+    pluginName.set(properties("pluginName"))
+    version.set(properties("platformVersion"))
+    type.set(properties("platformType"))
+    downloadSources.set(properties("platformDownloadSources").toBoolean())
+    updateSinceUntilBuild.set(true)
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    setPlugins(*properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty).toTypedArray())
+    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
 }
 
-// Configure gradle-changelog-plugin plugin.
-// Read more: https://github.com/JetBrains/gradle-changelog-plugin
+// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
-    version = properties("pluginVersion")
-    groups = emptyList()
+    version.set(properties("pluginVersion"))
+    groups.set(emptyList())
 }
 
 // Configure detekt plugin.
@@ -99,43 +97,41 @@ tasks {
     }
 
     patchPluginXml {
-        version(properties("pluginVersion"))
-        sinceBuild(properties("pluginSinceBuild"))
-        untilBuild(properties("pluginUntilBuild"))
+        version.set(properties("pluginVersion"))
+        sinceBuild.set(properties("pluginSinceBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription(
-            closure {
-                File(projectDir, "../README.md").readText().lines().run {
-                    val start = "<!-- Plugin description -->"
-                    val end = "<!-- Plugin description end -->"
+        pluginDescription.set(
+            projectDir.resolve("README.md").readText().lines().run {
+                val start = "<!-- Plugin description -->"
+                val end = "<!-- Plugin description end -->"
 
-                    if (!containsAll(listOf(start, end))) {
-                        throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
-                    }
-                    subList(indexOf(start) + 1, indexOf(end))
-                }.joinToString("\n").run { markdownToHTML(this) }
-            }
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end))
+            }.joinToString("\n").run { markdownToHTML(this) }
         )
 
         // Get the latest available change notes from the changelog file
-        changeNotes(
-            closure {
-                changelog.getLatest().toHTML()
-            }
-        )
+        changeNotes.set(provider {
+            changelog.run {
+                getOrNull(properties("pluginVersion")) ?: getLatest()
+            }.toHTML()
+        })
     }
 
     runPluginVerifier {
-        ideVersions(properties("pluginVerifierIdeVersions"))
+        ideVersions.set(properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty))
     }
 
     publishPlugin {
         dependsOn("patchChangelog")
-        token(System.getenv("PUBLISH_TOKEN"))
+        token.set(System.getenv("PUBLISH_TOKEN"))
         // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first())
+        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
 }

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -4,14 +4,14 @@
 pluginGroup = com.testknight
 pluginName = TestKnight
 pluginVersion = 1.0.1
-pluginSinceBuild = 202
+pluginSinceBuild = 203
 pluginUntilBuild = 212.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.2.4, 2020.3.2, 2021.1, 2021.2
+pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.1
 
 platformType = IC
-platformVersion = 2021.2
+platformVersion = 2020.3.4
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/plugin/src/main/kotlin/com/testknight/actions/testlist/TestListTraceabilityAction.kt
+++ b/plugin/src/main/kotlin/com/testknight/actions/testlist/TestListTraceabilityAction.kt
@@ -48,13 +48,13 @@ class TestListTraceabilityAction : ToggleAction() {
                     e.project?.service<TestTracingService>()
                         ?.highlightTest("${testUserObject.reference.testClassName},${testUserObject.reference.name}")
                 } catch (ex: TraceFileNotFoundException) {
-                    service<ExceptionHandlerService>().notify(ex)
+                    e.project?.service<ExceptionHandlerService>()?.notify(ex)
                     return
                 } catch (ex: CorruptedTraceFileException) {
-                    service<ExceptionHandlerService>().notify(ex)
+                    e.project?.service<ExceptionHandlerService>()?.notify(ex)
                     return
                 } catch (ex: NoTestCoverageDataException) {
-                    service<ExceptionHandlerService>().notify(ex)
+                    e.project?.service<ExceptionHandlerService>()?.notify(ex)
                     return
                 }
             }

--- a/plugin/src/main/kotlin/com/testknight/services/ExceptionHandlerService.kt
+++ b/plugin/src/main/kotlin/com/testknight/services/ExceptionHandlerService.kt
@@ -1,17 +1,11 @@
 package com.testknight.services
 
-import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
 import com.testknight.exceptions.TestKnightException
 
 class ExceptionHandlerService(private val project: Project) {
-
-    private val group = NotificationGroup.toolWindowGroup(
-        "testknight.notifications.toolWindow",
-        "TestKnight",
-        true
-    )
 
     /**
      * Display a notification with the provided title and content.
@@ -23,8 +17,10 @@ class ExceptionHandlerService(private val project: Project) {
      */
     fun notify(title: String, content: String, type: NotificationType) {
 
-        val notification = group.createNotification(title, content, type)
-        notification.notify(project)
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("testknight.notifications")
+            .createNotification(title, content, type)
+            .notify(project)
     }
 
     /**
@@ -34,7 +30,9 @@ class ExceptionHandlerService(private val project: Project) {
      * @param exception the TestKnightException for which the user should be notified
      */
     fun notify(exception: TestKnightException) {
-        val notification = group.createNotification(exception.title, exception.content, exception.type)
-        notification.notify(project)
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("testknight.notifications")
+            .createNotification(exception.title, exception.content, exception.type)
+            .notify(project)
     }
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -61,7 +61,10 @@
         <testStatusListener implementation="com.testknight.listeners.TestLoggingListener"/>
 
         <!-- Notifications -->
-        <notificationGroup id="testknight.notifications" displayType="TOOL_WINDOW"/>
+        <notificationGroup id="testknight.notifications"
+                           toolWindowId="TestKnight"
+                           displayType="TOOL_WINDOW"
+        />
 
         <!-- Intentions -->
         <intentionAction>

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -61,11 +61,7 @@
         <testStatusListener implementation="com.testknight.listeners.TestLoggingListener"/>
 
         <!-- Notifications -->
-        <notification.parentGroup id="testknight.notifications"
-                                  title="TestKnight notifications"/>
-
-        <notification.group parentId="testknight.notifications"
-                            groupId="testknight.notifications.toolWindow"/>
+        <notificationGroup id="testknight.notifications" displayType="TOOL_WINDOW"/>
 
         <!-- Intentions -->
         <intentionAction>


### PR DESCRIPTION
# What has changed between the versions
Changed the way notifications are registered as the previous way to do it is going to be deprecated (as a result, we cannot provide support to 2020.2). Also updated few dependency plugins to their latest version. 

# Why we need this pull request
Provides support to 2021.2.

# Change-log/Release notes
* Changed how notifications are registered (they are registered in plugin.xml now instead of in code.)
* Updated gradle wrapper from 7.0 -> 7.2
* Updated kotlin plugin from 1.4.32 -> 1.5.30
* Updated intellij plugin from 0.7.2 -> 1.1.6
* Updated changelog plugin from 1.1.2 -> 1.3.0
* Updated detekt plugin from 1.16.0 -> 1.18.1
* TestKnight now provides support to 2021.2 but not to 2020.2 anymore (support build 203 - 212.*)