### PR TITLE
Resolve propositional expression precedence bug

### DIFF
--- a/plugin/src/main/kotlin/com/testknight/models/PropositionalExpression.kt
+++ b/plugin/src/main/kotlin/com/testknight/models/PropositionalExpression.kt
@@ -21,7 +21,7 @@ class PropositionalExpression(private val psiExpression: PsiExpression) {
      * @return true if the precedence of the expression is less than that of an and operation
      */
     private fun isLowPrecedence(expression: PsiExpression): Boolean {
-        return PsiPrecedenceUtil.getPrecedence(expression) < PsiPrecedenceUtil.BINARY_AND_PRECEDENCE
+        return PsiPrecedenceUtil.getPrecedence(expression) < PsiPrecedenceUtil.AND_PRECEDENCE
     }
 
     /**

--- a/plugin/src/test/kotlin/com/testknight/models/PropositionalExpressionTest.kt
+++ b/plugin/src/test/kotlin/com/testknight/models/PropositionalExpressionTest.kt
@@ -96,4 +96,24 @@ internal class PropositionalExpressionTest : TestKnightTestCase() {
         TestCase.assertEquals(assignments["PROP2"], "b > c")
         TestCase.assertEquals(assignments["PROP3"], "!(a == b)")
     }
+
+    @Test
+    fun testSimplificationBitwiseOps() {
+        val psiElementFactory = PsiElementFactory.getInstance(project)
+
+        val expr = psiElementFactory.createExpressionFromText(
+            "a & b || a | c && a ^ d || ~d",
+            null
+        )
+
+        val (simplified, assignments) = PropositionalExpression(expr).simplified()
+
+        // ^, &, | and ~ should be used for binary numbers and thus should not be part of the simplified expr
+
+        TestCase.assertEquals("PROP3 || PROP2 && PROP1 || PROP0", simplified)
+        TestCase.assertEquals(assignments["PROP3"], "a & b")
+        TestCase.assertEquals(assignments["PROP2"], "a | c")
+        TestCase.assertEquals(assignments["PROP1"], "a ^ d")
+        TestCase.assertEquals(assignments["PROP0"], "~d")
+    }
 }


### PR DESCRIPTION
Changed `BINARY_AND_PRECEDENCE` to `AND_PRECEDENCE`. This resolves the minor bug which caused conditional expressions involving bitwise operators such as `&`, `|`, `^` and `~` to not behave as expected when generating checklist items.