### PR TITLE
Update testlist UI in background thread and change UserInterfaceHelper into a service

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -115,11 +115,13 @@ tasks {
         )
 
         // Get the latest available change notes from the changelog file
-        changeNotes.set(provider {
-            changelog.run {
-                getOrNull(properties("pluginVersion")) ?: getLatest()
-            }.toHTML()
-        })
+        changeNotes.set(
+            provider {
+                changelog.run {
+                    getOrNull(properties("pluginVersion")) ?: getLatest()
+                }.toHTML()
+            }
+        )
     }
 
     runPluginVerifier {

--- a/plugin/detekt-config.yml
+++ b/plugin/detekt-config.yml
@@ -282,6 +282,7 @@ formatting:
     continuationIndentSize: 4
   MaximumLineLength:
     active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
     maxLineLength: 120
     ignoreBackTickedIdentifier: false
   ModifierOrdering:
@@ -627,6 +628,7 @@ style:
     active: false
   MaxLineLength:
     active: true
+    excludes: [ '**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**' ]
     maxLineLength: 120
     excludePackageStatements: true
     excludeImportStatements: true

--- a/plugin/src/main/kotlin/com/testknight/actions/checklist/GenerateChecklistUnderCaretAction.kt
+++ b/plugin/src/main/kotlin/com/testknight/actions/checklist/GenerateChecklistUnderCaretAction.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.components.service
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.util.PsiTreeUtil
@@ -29,9 +30,9 @@ class GenerateChecklistUnderCaretAction : AnAction() {
         val checklistAction = ActionManager.getInstance().getAction("ChecklistAction") as LoadChecklistAction
 
         if (containingMethod != null && checklistAction.actionPerformed(project, containingMethod)) {
-            UserInterfaceHelper.showTab(project, "Checklist")
+            project.service<UserInterfaceHelper>().showTab("Checklist")
         } else if (containingClass != null && checklistAction.actionPerformed(project, containingClass)) {
-            UserInterfaceHelper.showTab(project, "Checklist")
+            project.service<UserInterfaceHelper>().showTab("Checklist")
         }
     }
 

--- a/plugin/src/main/kotlin/com/testknight/actions/testlist/ClearTestAction.kt
+++ b/plugin/src/main/kotlin/com/testknight/actions/testlist/ClearTestAction.kt
@@ -2,6 +2,7 @@ package com.testknight.actions.testlist
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.ui.treeStructure.Tree
 import com.testknight.utilities.UserInterfaceHelper
@@ -25,7 +26,7 @@ class ClearTestAction : AnAction() {
      * @param project current open project.
      */
     fun actionPerformed(project: Project) {
-        val viewport = UserInterfaceHelper.getTabViewport(project, "Test List") ?: return
+        val viewport = project.service<UserInterfaceHelper>().getTabViewport("Test List") ?: return
         val testListTree = viewport.view as Tree
         val root = testListTree.model.root as DefaultMutableTreeNode
         root.removeAllChildren()

--- a/plugin/src/main/kotlin/com/testknight/actions/testlist/DuplicateTestUnderCaretAction.kt
+++ b/plugin/src/main/kotlin/com/testknight/actions/testlist/DuplicateTestUnderCaretAction.kt
@@ -23,7 +23,7 @@ class DuplicateTestUnderCaretAction : AnAction() {
         val editor = event.getData(CommonDataKeys.EDITOR)!!
 
         if (duplicateTestsService.duplicateMethodUnderCaret(psiFile, editor)) {
-            UserInterfaceHelper.showTab(psiFile.project, "Test List")
+            project.service<UserInterfaceHelper>().showTab("Test List")
         }
         UsageDataService.instance.recordDuplicateTest()
     }

--- a/plugin/src/main/kotlin/com/testknight/actions/testlist/LoadTestAction.kt
+++ b/plugin/src/main/kotlin/com/testknight/actions/testlist/LoadTestAction.kt
@@ -52,7 +52,7 @@ class LoadTestAction : AnAction() {
             return
         }
 
-        val testListViewport = UserInterfaceHelper.getTabViewport(project, "Test List") ?: return
+        val testListViewport = project.service<UserInterfaceHelper>().getTabViewport("Test List") ?: return
         val testListTree = testListViewport.view as Tree
         val root = testListTree.model.root as DefaultMutableTreeNode
         root.removeAllChildren()

--- a/plugin/src/main/kotlin/com/testknight/listeners/PsiTreeListener.kt
+++ b/plugin/src/main/kotlin/com/testknight/listeners/PsiTreeListener.kt
@@ -1,5 +1,6 @@
 package com.testknight.listeners
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiTreeChangeAdapter
@@ -25,31 +26,31 @@ class PsiTreeListener(val project: Project) : PsiTreeChangeAdapter() {
 
     override fun childAdded(event: PsiTreeChangeEvent) {
         if (checkElement(event.child)) {
-            UserInterfaceHelper.refreshTestCaseUI(project)
+            project.service<UserInterfaceHelper>().refreshTestCaseUI()
         }
     }
 
     override fun childRemoved(event: PsiTreeChangeEvent) {
         if (checkElement(event.parent)) {
-            UserInterfaceHelper.refreshTestCaseUI(project)
+            project.service<UserInterfaceHelper>().refreshTestCaseUI()
         } else if (event.child != null && event.child is PsiMethodImpl) {
             // testAnalyzer.isTestMethod(event.child as PsiMethodImpl) seems to throw exception.
             // So currently, this will be called even if removed method is not a test method.
-            UserInterfaceHelper.refreshTestCaseUI(project)
+            project.service<UserInterfaceHelper>().refreshTestCaseUI()
         }
     }
 
     override fun childReplaced(event: PsiTreeChangeEvent) {
         if (checkElement(event.parent)) {
-            UserInterfaceHelper.refreshTestCaseUI(project)
+            project.service<UserInterfaceHelper>().refreshTestCaseUI()
         } else if (checkElement(event.child)) {
-            UserInterfaceHelper.refreshTestCaseUI(project)
+            project.service<UserInterfaceHelper>().refreshTestCaseUI()
         }
     }
 
     override fun childMoved(event: PsiTreeChangeEvent) {
         if (checkElement(event.child)) {
-            UserInterfaceHelper.refreshTestCaseUI(project)
+            project.service<UserInterfaceHelper>().refreshTestCaseUI()
         }
     }
 

--- a/plugin/src/main/kotlin/com/testknight/listeners/checklist/ClassChecklistIconHandler.kt
+++ b/plugin/src/main/kotlin/com/testknight/listeners/checklist/ClassChecklistIconHandler.kt
@@ -1,6 +1,7 @@
 package com.testknight.listeners.checklist
 
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import com.testknight.actions.checklist.LoadChecklistAction
 import com.testknight.utilities.UserInterfaceHelper
@@ -21,7 +22,7 @@ class ClassChecklistIconHandler : GutterIconNavigationHandler<PsiElement> {
         if (element == null) return
         val project = element.project
         if (LoadChecklistAction().actionPerformed(project, element.parent)) {
-            UserInterfaceHelper.showTab(project, "Checklist")
+            project.service<UserInterfaceHelper>().showTab("Checklist")
         }
     }
 }

--- a/plugin/src/main/kotlin/com/testknight/listeners/checklist/MethodChecklistIconHandler.kt
+++ b/plugin/src/main/kotlin/com/testknight/listeners/checklist/MethodChecklistIconHandler.kt
@@ -1,6 +1,7 @@
 package com.testknight.listeners.checklist
 
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.openapi.components.service
 import com.intellij.psi.PsiElement
 import com.testknight.actions.checklist.LoadChecklistAction
 import com.testknight.utilities.UserInterfaceHelper
@@ -21,7 +22,7 @@ class MethodChecklistIconHandler : GutterIconNavigationHandler<PsiElement> {
         if (element == null) return
         val project = element.project
         if (LoadChecklistAction().actionPerformed(project, element.parent)) {
-            UserInterfaceHelper.showTab(project, "Checklist")
+            project.service<UserInterfaceHelper>().showTab("Checklist")
         }
     }
 }

--- a/plugin/src/main/kotlin/com/testknight/utilities/UserInterfaceHelper.kt
+++ b/plugin/src/main/kotlin/com/testknight/utilities/UserInterfaceHelper.kt
@@ -23,25 +23,25 @@ class UserInterfaceHelper private constructor() {
          * @param project the current project.
          */
         fun refreshTestCaseUI(project: Project) {
-            val textEditor = FileEditorManager.getInstance(project).selectedEditor as TextEditor?
+            val textEditor = FileEditorManager.getInstance(project).selectedEditor
+
+            if(textEditor !is TextEditor) {
+                return;
+            }
 
             val actionManager = ActionManager.getInstance()
             val clearTestAction =
                 (actionManager.getAction("ClearTestAction") ?: return) as ClearTestAction
 
-            if (textEditor != null) {
-                val psiFile = PsiManager.getInstance(project).findFile(textEditor.file!!)
+            val psiFile = PsiManager.getInstance(project).findFile(textEditor.file!!)
 
-                if (psiFile == null) {
-                    clearTestAction.actionPerformed(project)
-                } else {
-                    val loadTestAction =
-                        (actionManager.getAction("LoadTestAction") ?: return) as LoadTestAction
-
-                    loadTestAction.actionPerformed(project, psiFile, textEditor.editor)
-                }
-            } else {
+            if (psiFile == null) {
                 clearTestAction.actionPerformed(project)
+            } else {
+                val loadTestAction =
+                    (actionManager.getAction("LoadTestAction") ?: return) as LoadTestAction
+
+                loadTestAction.actionPerformed(project, psiFile, textEditor.editor)
             }
         }
 

--- a/plugin/src/main/kotlin/com/testknight/utilities/UserInterfaceHelper.kt
+++ b/plugin/src/main/kotlin/com/testknight/utilities/UserInterfaceHelper.kt
@@ -14,89 +14,88 @@ import com.testknight.actions.testlist.LoadTestAction
 import javax.swing.JTabbedPane
 import javax.swing.JViewport
 
-class UserInterfaceHelper private constructor() {
-    companion object {
-        /**
-         * Updates the TestListTab by calling the LoadTestAction.
-         * Uses the project to get editor and psi file information.
-         *
-         * @param project the current project.
-         */
-        fun refreshTestCaseUI(project: Project) {
-            val textEditor = FileEditorManager.getInstance(project).selectedEditor
+class UserInterfaceHelper(private val project: Project) {
 
-            if(textEditor !is TextEditor) {
-                return;
-            }
+    /**
+     * Updates the TestListTab by calling the LoadTestAction.
+     * Uses the project to get editor and psi file information.
+     *
+     * @param project the current project.
+     */
+    fun refreshTestCaseUI() {
+        val textEditor = FileEditorManager.getInstance(project).selectedEditor
 
-            val actionManager = ActionManager.getInstance()
-            val clearTestAction =
-                (actionManager.getAction("ClearTestAction") ?: return) as ClearTestAction
-
-            val psiFile = PsiManager.getInstance(project).findFile(textEditor.file!!)
-
-            if (psiFile == null) {
-                clearTestAction.actionPerformed(project)
-            } else {
-                val loadTestAction =
-                    (actionManager.getAction("LoadTestAction") ?: return) as LoadTestAction
-
-                loadTestAction.actionPerformed(project, psiFile, textEditor.editor)
-            }
+        if (textEditor !is TextEditor) {
+            return
         }
 
-        /**
-         * Gets the Tab in the TestKnight tool window with the given tab name.
-         *
-         * @param project Current open project.
-         * @param tabName Name of the tab which needs to be returned.
-         * @return The first tab with the name mentioned in tabName.
-         *         If no such tab is found, returns null.
-         */
-        private fun getTab(project: Project, tabName: String): JBPanelWithEmptyText? {
+        val actionManager = ActionManager.getInstance()
+        val clearTestAction =
+            (actionManager.getAction("ClearTestAction") ?: return) as ClearTestAction
 
-            val window = ToolWindowManager.getInstance(project).getToolWindow("TestKnight") ?: return null
+        val psiFile = PsiManager.getInstance(project).findFile(textEditor.file!!)
 
-            val tabbedPane = (
-                (window.contentManager.contents[0] as ContentImpl)
-                    .component as JTabbedPane
-                )
-            val tabIndex = tabbedPane.indexOfTab(tabName)
-            if (tabIndex == -1) return null
+        if (psiFile == null) {
+            clearTestAction.actionPerformed(project)
+        } else {
+            val loadTestAction =
+                (actionManager.getAction("LoadTestAction") ?: return) as LoadTestAction
 
-            return tabbedPane.getComponentAt(tabIndex) as JBPanelWithEmptyText
+            loadTestAction.actionPerformed(project, psiFile, textEditor.editor)
         }
+    }
 
-        /**
-         * Gets the viewport of the tab in the TestKnight tool window with the given tab name.
-         *
-         * @param project Current open project.
-         * @param tabName Name of the tab which needs to be returned.
-         * @return The viewport of the first tab with the name mentioned in tabName.
-         *         If no such tab is found, returns null.
-         */
-        fun getTabViewport(project: Project, tabName: String): JViewport? {
-            val tab = getTab(project, tabName) ?: return null
-            val tabScrollPane = tab.getComponent(1) as JBScrollPane
-            return tabScrollPane.viewport
-        }
+    /**
+     * Gets the Tab in the TestKnight tool window with the given tab name.
+     *
+     * @param project Current open project.
+     * @param tabName Name of the tab which needs to be returned.
+     * @return The first tab with the name mentioned in tabName.
+     *         If no such tab is found, returns null.
+     */
+    private fun getTab(tabName: String): JBPanelWithEmptyText? {
 
-        /**
-         * Opens the Tab in the TestKnight tool window with the given tab name.
-         *
-         * @param project Current open project.
-         * @param tabName Name of the tab which needs to be returned.
-         */
-        fun showTab(project: Project, tabName: String) {
-            val window = ToolWindowManager.getInstance(project).getToolWindow("TestKnight") ?: return
-            val tabbedPane = (
-                (window.contentManager.contents[0] as ContentImpl)
-                    .component as JTabbedPane
-                )
-            val tabIndex = tabbedPane.indexOfTab(tabName)
-            if (tabIndex == -1) return
-            window.show()
-            tabbedPane.selectedIndex = tabIndex
-        }
+        val window = ToolWindowManager.getInstance(project).getToolWindow("TestKnight") ?: return null
+
+        val tabbedPane = (
+            (window.contentManager.contents[0] as ContentImpl)
+                .component as JTabbedPane
+            )
+        val tabIndex = tabbedPane.indexOfTab(tabName)
+        if (tabIndex == -1) return null
+
+        return tabbedPane.getComponentAt(tabIndex) as JBPanelWithEmptyText
+    }
+
+    /**
+     * Gets the viewport of the tab in the TestKnight tool window with the given tab name.
+     *
+     * @param project Current open project.
+     * @param tabName Name of the tab which needs to be returned.
+     * @return The viewport of the first tab with the name mentioned in tabName.
+     *         If no such tab is found, returns null.
+     */
+    fun getTabViewport(tabName: String): JViewport? {
+        val tab = getTab(tabName) ?: return null
+        val tabScrollPane = tab.getComponent(1) as JBScrollPane
+        return tabScrollPane.viewport
+    }
+
+    /**
+     * Opens the Tab in the TestKnight tool window with the given tab name.
+     *
+     * @param project Current open project.
+     * @param tabName Name of the tab which needs to be returned.
+     */
+    fun showTab(tabName: String) {
+        val window = ToolWindowManager.getInstance(project).getToolWindow("TestKnight") ?: return
+        val tabbedPane = (
+            (window.contentManager.contents[0] as ContentImpl)
+                .component as JTabbedPane
+            )
+        val tabIndex = tabbedPane.indexOfTab(tabName)
+        if (tabIndex == -1) return
+        window.show()
+        tabbedPane.selectedIndex = tabIndex
     }
 }

--- a/plugin/src/main/kotlin/com/testknight/views/UserInterface.kt
+++ b/plugin/src/main/kotlin/com/testknight/views/UserInterface.kt
@@ -2,6 +2,7 @@ package com.testknight.views
 
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
@@ -43,11 +44,10 @@ import javax.swing.table.DefaultTableModel
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreeSelectionModel
 
-
 class UserInterface(val project: Project) {
 
     private var mainUI: JBTabbedPane = JBTabbedPane()
-    private lateinit var  testCaseTree: Tree
+    private lateinit var testCaseTree: Tree
 
     /**
      * Gets the component to be displayed on the tool window.
@@ -244,7 +244,11 @@ class UserInterface(val project: Project) {
                 FileEditorManagerListener.FILE_EDITOR_MANAGER,
                 object : FileEditorManagerListener {
                     override fun selectionChanged(@NotNull event: FileEditorManagerEvent) {
-                        UserInterfaceHelper.refreshTestCaseUI(project)
+                        ApplicationManager.getApplication().invokeLater {
+                            ApplicationManager.getApplication().runReadAction {
+                                project.service<UserInterfaceHelper>().refreshTestCaseUI()
+                            }
+                        }
                     }
                 }
             )

--- a/plugin/src/main/kotlin/com/testknight/views/UserInterface.kt
+++ b/plugin/src/main/kotlin/com/testknight/views/UserInterface.kt
@@ -39,7 +39,7 @@ import com.testknight.views.trees.TestListCellRenderer
 import org.jetbrains.annotations.NotNull
 import java.awt.Component
 import java.awt.Insets
-import java.util.*
+import java.util.Vector
 import javax.swing.table.DefaultTableModel
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreeSelectionModel

--- a/plugin/src/main/kotlin/com/testknight/views/UserInterface.kt
+++ b/plugin/src/main/kotlin/com/testknight/views/UserInterface.kt
@@ -38,22 +38,23 @@ import com.testknight.views.trees.TestListCellRenderer
 import org.jetbrains.annotations.NotNull
 import java.awt.Component
 import java.awt.Insets
-import java.util.Vector
+import java.util.*
 import javax.swing.table.DefaultTableModel
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreeSelectionModel
 
+
 class UserInterface(val project: Project) {
 
-    private var mainUI: JBTabbedPane? = null
-    private var testCaseTree: Tree? = null
+    private var mainUI: JBTabbedPane = JBTabbedPane()
+    private lateinit var  testCaseTree: Tree
 
     /**
      * Gets the component to be displayed on the tool window.
      *
      * @return The JBTabbedPane which will be shown on the tool window.
      */
-    fun getContent(): JBTabbedPane? {
+    fun getContent(): JBTabbedPane {
         return mainUI
     }
 
@@ -80,6 +81,7 @@ class UserInterface(val project: Project) {
         actionGroup.add(editItem)
         actionGroup.add(generateTestMethod)
         val actionToolbar = actionManager.createActionToolbar("ChecklistToolbar", actionGroup, true)
+        actionToolbar.setTargetComponent(toolWindowPanel)
         toolWindowPanel.toolbar = actionToolbar.component
 
         val service = project.service<ChecklistTreeService>()
@@ -133,6 +135,7 @@ class UserInterface(val project: Project) {
         val traceabilityAction = actionManager.getAction("TestListTraceabilityAction")
         actionGroup.add(traceabilityAction)
         val actionToolbar = actionManager.createActionToolbar("TestListToolbar", actionGroup, true)
+        actionToolbar.setTargetComponent(toolWindowPanel)
         toolWindowPanel.toolbar = actionToolbar.component
 
         val panel = JBScrollPane()
@@ -142,24 +145,24 @@ class UserInterface(val project: Project) {
         testCaseTree = Tree(root)
 
         val cellRenderer = TestListCellRenderer()
-        testCaseTree!!.cellRenderer = cellRenderer
-        testCaseTree!!.isEditable = false
-        testCaseTree!!.isRootVisible = false
-        testCaseTree!!.showsRootHandles = true
-        testCaseTree!!.selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+        testCaseTree.cellRenderer = cellRenderer
+        testCaseTree.isEditable = false
+        testCaseTree.isRootVisible = false
+        testCaseTree.showsRootHandles = true
+        testCaseTree.selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
 
-        val mouseListener = TestListMouseListener(testCaseTree!!, cellRenderer)
-        val keyboardListener = TestListKeyboardListener(testCaseTree!!, project)
-        mouseListener.installOn(testCaseTree!!)
-        testCaseTree!!.addKeyListener(keyboardListener)
-        testCaseTree!!.addTreeSelectionListener(
+        val mouseListener = TestListMouseListener(testCaseTree, cellRenderer)
+        val keyboardListener = TestListKeyboardListener(testCaseTree, project)
+        mouseListener.installOn(testCaseTree)
+        testCaseTree.addKeyListener(keyboardListener)
+        testCaseTree.addTreeSelectionListener(
             TestListSelectionListener(
                 project,
                 traceabilityAction as TestListTraceabilityAction
             )
         )
 
-        traceabilityAction.setTree(testCaseTree!!)
+        traceabilityAction.setTree(testCaseTree)
 
         panel.setViewportView(testCaseTree)
         toolWindowPanel.setContent(panel)
@@ -185,6 +188,7 @@ class UserInterface(val project: Project) {
         actionGroup.add(actionManager.getAction("ShowIntegratedView"))
         actionGroup.add(actionManager.getAction("HideIntegratedView"))
         val actionToolbar = actionManager.createActionToolbar("CoverageToolbar", actionGroup, true)
+        actionToolbar.setTargetComponent(toolWindowPanel)
         toolWindowPanel.toolbar = actionToolbar.component
 
         val panel = ScrollPaneFactory.createScrollPane()
@@ -221,15 +225,14 @@ class UserInterface(val project: Project) {
      * The MainUI will be a Tabbed pane with a testList and Checklist tab.
      */
     init {
-        mainUI = JBTabbedPane()
-        mainUI!!.tabComponentInsets = Insets(0, 0, 0, 0)
+        mainUI.tabComponentInsets = Insets(0, 0, 0, 0)
 
         // Function call which returns the tab for copy paste
-        mainUI!!.addTab("Test List", getTestListTab())
+        mainUI.addTab("Test List", getTestListTab())
         // Function call which returns the tab for checklist
-        mainUI!!.addTab("Checklist", createCheckList())
+        mainUI.addTab("Checklist", createCheckList())
         // Function call which returns the tab for coverage
-        mainUI!!.addTab("Coverage", createCoverage())
+        mainUI.addTab("Coverage", createCoverage())
 
         val loadTestsService = project.service<LoadTestsService>()
 

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,7 @@
         <projectService serviceImplementation="com.testknight.services.TestMethodGenerationService"/>
         <projectService serviceImplementation="com.testknight.services.checklist.ChecklistTreePersistent"/>
         <projectService serviceImplementation="com.testknight.services.ExceptionHandlerService"/>
+        <projectService serviceImplementation="com.testknight.utilities.UserInterfaceHelper"/>
 
         <!-- Application services -->
         <applicationService serviceImplementation="com.testknight.services.checklist.GenerateTestCaseChecklistService"/>

--- a/plugin/src/test/kotlin/com/testknight/checklistGenerationStrategies/leafStrategies/branchingStatements/ConditionalExpressionChecklistGenerationStrategyTest.kt
+++ b/plugin/src/test/kotlin/com/testknight/checklistGenerationStrategies/leafStrategies/branchingStatements/ConditionalExpressionChecklistGenerationStrategyTest.kt
@@ -44,7 +44,7 @@ internal class ConditionalExpressionChecklistGenerationStrategyTest : TestKnight
 
     @Test
     fun testMissingConditionReturnsEmptyChecklist() {
-        val data = getBasicTestInfo("/BrokenTernary.java")
+        getBasicTestInfo("/BrokenTernary.java")
         val method = getMethodByName("incompleteConditionalExpression")
 
         val conditionalExpression = PsiTreeUtil.findChildOfType(method, PsiConditionalExpression::class.java)


### PR DESCRIPTION
# What has changed between the versions
Moved ``refreshTestCaseUI`` call when user changes test method name to run on a background thread instead of main UI thread. Made ``UserInterfaceHelper`` into a project-level service as that makes more sense for its purpose. Along with this, made a few formatting changes and excluded MaxLineLength and related warnings to exclude test classes.

# Why we need this pull request
``refreshTestCaseUI`` call is a slow operation and it is recommended not to have slow operations on the UI thread (was a warning when running the plugin). Other changes were mainly to keep the code clean.

# Change-log/Release notes
* Moved ``refreshTestCaseUI`` call in ``FileEditorManagerListener`` to be run in a background thread.
* Changed ``UserInterfaceHelper`` to be a service instead of a companion object class.
* Excluded line length requirements from test classes.
* Minor formatting changes in few files.